### PR TITLE
optimization

### DIFF
--- a/src/hooks/useImages.ts
+++ b/src/hooks/useImages.ts
@@ -1,5 +1,5 @@
 // src/hooks/useImages.ts
-import useSWR from "swr";
+import useSWRInfinite from "swr/infinite";
 import type { ApiImage } from "@/types/api";
 
 const fetcher = async (url: string): Promise<ApiImage[]> => {
@@ -8,11 +8,43 @@ const fetcher = async (url: string): Promise<ApiImage[]> => {
   return res.json() as Promise<ApiImage[]>;
 };
 
+const PAGE_LIMIT = 20;
+
 export function useImages(params?: { slugs?: string[]; mode?: "any" | "all" }) {
-  const qs = new URLSearchParams();
-  if (params?.slugs?.length) qs.set("tags", params.slugs.join(","));
-  if (params?.mode === "all") qs.set("mode", "all");
-  const key = `/api/images${qs.toString() ? `?${qs}` : ""}`;
-  const { data, error, isLoading } = useSWR<ApiImage[]>(key, fetcher);
-  return { images: data ?? [], isLoading, error };
+  const getKey = (pageIndex: number, previousPageData: ApiImage[]) => {
+    // Reached the end
+    if (previousPageData && !previousPageData.length) return null;
+
+    const qs = new URLSearchParams();
+    if (params?.slugs?.length) qs.set("tags", params.slugs.join(","));
+    if (params?.mode === "all") qs.set("mode", "all");
+    qs.set("page", (pageIndex + 1).toString());
+    qs.set("limit", PAGE_LIMIT.toString());
+
+    return `/api/images?${qs.toString()}`;
+  };
+
+  const { data, error, isLoading, size, setSize, isValidating } =
+    useSWRInfinite<ApiImage[]>(getKey, fetcher, {
+      revalidateFirstPage: false,
+      persistSize: true,
+    });
+
+  const images = data ? data.flat() : [];
+  const isLoadingMore =
+    isLoading || (size > 0 && data && typeof data[size - 1] === "undefined");
+  const isEmpty = data?.[0]?.length === 0;
+  const isReachingEnd =
+    isEmpty || (data && data[data.length - 1]?.length < PAGE_LIMIT);
+
+  return {
+    images,
+    isLoading,
+    isLoadingMore,
+    isReachingEnd,
+    size,
+    setSize,
+    error,
+    isValidating,
+  };
 }


### PR DESCRIPTION
API Pagination
I updated the 
GET
 handler in 
src/app/api/images/route.ts
 to support page and limit query parameters. It now uses Supabase's range() method to fetch only the requested subset of images.

Infinite Scroll Hook
I refactored 
src/hooks/useImages.ts
 to use useSWRInfinite instead of useSWR. This allows for:

Fetching images in pages (default 20 images per page).
Appending new pages to the existing list.
Managing loading states for initial load and subsequent pages.
UI Updates
I updated 
src/components/gallery/PhotoGallery.tsx
 to:

Integrate with the new 
useImages
 hook.
Add an IntersectionObserver to automatically load more images when the user scrolls to the bottom of the gallery.
Display a loading indicator while fetching more images.
Verification Results
Build Verification
Ran npm run build to ensure type safety and build integrity.

Result: Build successful.
Manual Verification Steps
Initial Load: The gallery loads the first 20 images.
Scroll: Scrolling to the bottom triggers the "Load More" action, fetching the next set of images.
Filtering: Selecting a category resets the list and loads images for that category, with infinite scroll working for the filtered results.
Lightbox: Opening an image and navigating works correctly with the incrementally loaded list.